### PR TITLE
[1/?] The color config option has been moved to ui.color

### DIFF
--- a/test/helper.py
+++ b/test/helper.py
@@ -133,7 +133,7 @@ class TestHelper(Assertions):
 
         self.config['plugins'] = []
         self.config['verbose'] = True
-        self.config['color'] = False
+        self.config['ui']['color'] = False
         self.config['threaded'] = False
         self.config['import']['copy'] = False
 


### PR DESCRIPTION
First in a series of PRs to backport changes from  [wisp3rwind/beets-alternatives](https://github.com/wisp3rwind/beets-alternatives) to this repo

Very minor fix to test setup that didn't even lead to test failures:
```
The color config option has been moved to ui.color
and while beets used to respect the legacy top-level color config
(emitting a deprection warning, though), it doesn't since the following commit:

be8fe875 commit 2016-09-25 - Remove deprecated top level colors config option (#2209)
```