### PR TITLE
[2/?] Use the logger provided as BeetsPlugin._log, fixes parallel imports crashing

### DIFF
--- a/test/helper.py
+++ b/test/helper.py
@@ -1,13 +1,13 @@
 import sys
 import os
 import tempfile
-import logging
 import shutil
 from contextlib import contextmanager
 from StringIO import StringIO
 from concurrent import futures
 
 import beets
+from beets import logging
 from beets import plugins
 from beets import ui
 from beets.library import Item
@@ -27,7 +27,7 @@ class LogCapture(logging.Handler):
         self.messages = []
 
     def emit(self, record):
-        self.messages.append(str(record.msg))
+        self.messages.append(unicode(record.msg))
 
 
 @contextmanager


### PR DESCRIPTION
Second in a series of PRs to backport changes from  [wisp3rwind/beets-alternatives](https://github.com/wisp3rwind/beets-alternatives) to this repo

```
Use the logger provided as BeetsPlugin._log, fixes parallel imports crashing...

...on a log level assertion in recent beets versions. Originally, this
fix was committed in 2016, and I don't quite remember the circumstances
crashes happened under. However, looking at the code for beets.plugins,
beets is clearly expecting plugins to use the logger provided through
the plugin class. Thus, it seems this change should be applied whether
or not these crashes could still occur.

```