### PR TITLE
Support Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,22 @@ notifications:
 
 language: python
 
-env:
-  - TOX_ENV=beets_master COVERAGE=1
-  - TOX_ENV=beets_1.4.1
-  - TOX_ENV=flake8
+branches:
+  only:
+    master
+
+matrix:
+  include:
+    - env: TOX_ENV=py27-beets_master
+      python: 2.7
+    - env: TOX_ENV=py27-beets_release
+      python: 2.7
+    - env: TOX_ENV=py36-beets_master COVERAGE=1
+      python: 3.6
+    - env: TOX_ENV=py36-beets_release
+      python: 3.6
+    - env: TOX_ENV=py36-flake8
+      python: 3.6
 
 install:
   - "pip install tox"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,6 @@ notifications:
 
 language: python
 
-branches:
-  only:
-    master
-
 matrix:
   include:
     - env: TOX_ENV=py27-beets_master

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Change Log
 ## Upcoming
 * Require at least beets v1.4.1
 * Update album art in alternatives when it changes
+* Python 3 support (Python 2.7 continuous to be supported)
 
 ## v0.8.2 - 2015-05-31
 * Fix a bug that made the plugin crash when reading unicode strings

--- a/beetsplug/alternatives.py
+++ b/beetsplug/alternatives.py
@@ -15,6 +15,7 @@ import os.path
 import threading
 from argparse import ArgumentParser
 from concurrent import futures
+import six
 
 import beets
 from beets import util, art
@@ -24,13 +25,6 @@ from beets.library import parse_query_string, Item
 from beets.util import syspath, displayable_path, cpu_count, bytestring_path
 
 from beetsplug import convert
-
-
-def get_unicode_config(config, key):
-    ret = config[key].get(str)
-    if type(ret) != unicode:
-        ret = unicode(ret, 'utf8')
-    return ret
 
 
 class AlternativesPlugin(BeetsPlugin):
@@ -55,8 +49,8 @@ class AlternativesPlugin(BeetsPlugin):
             raise KeyError(name)
 
         if conf['formats'].exists():
-            fmt = conf['formats'].get(unicode)
-            if fmt == 'link':
+            fmt = conf['formats'].as_str()
+            if fmt == u'link':
                 return SymlinkView(self._log, name, lib, conf)
             else:
                 return ExternalConvert(self._log, name, fmt.split(), lib, conf)
@@ -100,7 +94,7 @@ class External(object):
         self._log = log
         self.name = name
         self.lib = lib
-        self.path_key = 'alt.{0}'.format(name)
+        self.path_key = u'alt.{0}'.format(name)
         self.parse_config(config)
 
     def parse_config(self, config):
@@ -109,13 +103,13 @@ class External(object):
         else:
             path_config = beets.config['paths']
         self.path_formats = get_path_formats(path_config)
-        query = get_unicode_config(config, 'query')
+        query = config['query'].as_str()
         self.query, _ = parse_query_string(query, Item)
 
         self.removable = config.get(dict).get('removable', True)
 
         if 'directory' in config:
-            dir = config['directory'].get(str)
+            dir = config['directory'].as_str()
         else:
             dir = self.name
         if not os.path.isabs(dir):
@@ -211,7 +205,7 @@ class External(object):
                                 path_formats=self.path_formats)
 
     def set_path(self, item, path):
-        item[self.path_key] = unicode(path, 'utf8')
+        item[self.path_key] = six.text_type(path, 'utf8')
 
     def get_path(self, item):
         try:
@@ -277,7 +271,7 @@ class ExternalConvert(External):
     def destination(self, item):
         dest = super(ExternalConvert, self).destination(item)
         if self.should_transcode(item):
-            return os.path.splitext(dest)[0] + '.' + self.ext
+            return os.path.splitext(dest)[0] + b'.' + self.ext
         else:
             return dest
 
@@ -289,7 +283,7 @@ class SymlinkView(External):
 
     def parse_config(self, config):
         if 'query' not in config:
-            config['query'] = ''  # This is a TrueQuery()
+            config['query'] = u''  # This is a TrueQuery()
         super(SymlinkView, self).parse_config(config)
 
     def update(self, create=None):

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
 
     install_requires=[
         'beets>=1.4.7',
-        'futures',
+        'futures; python_version<"3"',
     ],
 
     classifiers=[
@@ -26,7 +26,11 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Environment :: Console',
         'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ setup(
     install_requires=[
         'beets>=1.4.7',
         'futures; python_version<"3"',
+        'six',
     ],
 
     classifiers=[

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -21,9 +21,9 @@ class DocTest(TestHelper):
         self.config['alternatives'] = {
             'myplayer': {
                 'directory': external_dir,
-                'paths': {'default': '$artist/$title'},
-                'formats': 'aac mp3',
-                'query': 'onplayer:true',
+                'paths': {'default': u'$artist/$title'},
+                'formats': u'aac mp3',
+                'query': u'onplayer:true',
                 'removable': True,
             }
         }
@@ -43,9 +43,9 @@ class DocTest(TestHelper):
             out = self.runcli('alt', 'update', 'myplayer')
             self.assertIn('Do you want to create the collection?', out)
 
-        self.assertNotFileTag(external_from_mp3, 'ISAAC')
-        self.assertNotFileTag(external_from_m4a, 'ISAAC')
-        self.assertFileTag(external_from_ogg, 'ISAAC')
+        self.assertNotFileTag(external_from_mp3, b'ISAAC')
+        self.assertNotFileTag(external_from_m4a, b'ISAAC')
+        self.assertFileTag(external_from_ogg, b'ISAAC')
         self.assertFalse(os.path.isfile(external_beet))
 
         self.runcli('modify', '--yes', 'composer=JSB', 'artist:Bach')
@@ -61,7 +61,7 @@ class DocTest(TestHelper):
         self.assertFalse(os.path.isfile(external_from_mp3))
         self.assertFalse(os.path.isfile(external_from_m4a))
         self.assertFalse(os.path.isfile(external_from_ogg))
-        self.assertFileTag(external_beet, 'ISAAC')
+        self.assertFileTag(external_beet, b'ISAAC')
 
     def test_symlink_view(self):
         self.set_paths_config({
@@ -92,7 +92,7 @@ class ExternalCopyTest(TestHelper):
         self.config['alternatives'] = {
             'myexternal': {
                 'directory': self.external_dir,
-                'query': 'myexternal:true',
+                'query': u'myexternal:true',
             }
         }
         self.external_config = self.config['alternatives']['myexternal']
@@ -293,7 +293,7 @@ class ExternalConvertTest(TestHelper):
         self.config['alternatives'] = {
             'myexternal': {
                 'directory': self.external_dir,
-                'query': 'myexternal:true',
+                'query': u'myexternal:true',
                 'formats': 'ogg mp3'
             }
         }
@@ -304,7 +304,7 @@ class ExternalConvertTest(TestHelper):
         self.runcli('alt', 'update', 'myexternal')
         item.load()
         converted_path = item['alt.myexternal']
-        self.assertFileTag(converted_path, 'ISOGG')
+        self.assertFileTag(converted_path, b'ISOGG')
 
     def test_convert_and_embed(self):
         self.config['convert']['embed'] = True
@@ -324,7 +324,7 @@ class ExternalConvertTest(TestHelper):
         self.runcli('alt', 'update', 'myexternal')
         item.load()
         converted_path = item['alt.myexternal']
-        self.assertNotFileTag(converted_path, 'ISOGG')
+        self.assertNotFileTag(converted_path, b'ISOGG')
 
     def test_skip_convert_for_alternative_format(self):
         item = self.add_track(myexternal='true')
@@ -333,7 +333,7 @@ class ExternalConvertTest(TestHelper):
         self.runcli('alt', 'update', 'myexternal')
         item.load()
         converted_path = item['alt.myexternal']
-        self.assertNotFileTag(converted_path, 'ISOGG')
+        self.assertNotFileTag(converted_path, b'ISOGG')
 
 
 class ExternalRemovableTest(TestHelper):
@@ -344,7 +344,7 @@ class ExternalRemovableTest(TestHelper):
         self.config['alternatives'] = {
             'myexternal': {
                 'directory': external_dir,
-                'query': '',
+                'query': u'',
             }
         }
         self.external_config = self.config['alternatives']['myexternal']

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -1,14 +1,13 @@
 import os
 import os.path
 import shutil
-from unittest import TestCase
 
 from helper import TestHelper, control_stdin
 
 from beets.mediafile import MediaFile
 
 
-class DocTest(TestHelper, TestCase):
+class DocTest(TestHelper):
 
     def test_external(self):
         external_dir = os.path.join(self.mkdtemp(), 'myplayer')
@@ -85,7 +84,7 @@ class DocTest(TestHelper, TestCase):
         )
 
 
-class ExternalCopyTest(TestHelper, TestCase):
+class ExternalCopyTest(TestHelper):
 
     def setUp(self):
         super(ExternalCopyTest, self).setUp()
@@ -282,7 +281,7 @@ class ExternalCopyTest(TestHelper, TestCase):
                                       self.IMAGE_FIXTURE2)
 
 
-class ExternalConvertTest(TestHelper, TestCase):
+class ExternalConvertTest(TestHelper):
 
     def setUp(self):
         super(ExternalConvertTest, self).setUp()
@@ -337,7 +336,7 @@ class ExternalConvertTest(TestHelper, TestCase):
         self.assertNotFileTag(converted_path, 'ISOGG')
 
 
-class ExternalRemovableTest(TestHelper, TestCase):
+class ExternalRemovableTest(TestHelper):
 
     def setUp(self):
         super(ExternalRemovableTest, self).setUp()

--- a/test/helper.py
+++ b/test/helper.py
@@ -3,7 +3,7 @@ import os
 import tempfile
 import shutil
 from contextlib import contextmanager
-from StringIO import StringIO
+from six import StringIO
 from concurrent import futures
 from zlib import crc32
 from unittest import TestCase
@@ -48,20 +48,37 @@ def capture_log(logger='beets'):
 
 @contextmanager
 def capture_stdout():
+    """Save stdout in a StringIO.
+
+    >>> with capture_stdout() as output:
+    ...     print('spam')
+    ...
+    >>> output.getvalue()
+    'spam'
+    """
     org = sys.stdout
-    sys.stdout = captured = StringIO()
+    sys.stdout = capture = StringIO()
+    if six.PY2:  # StringIO encoding attr isn't writable in python >= 3
+        sys.stdout.encoding = 'utf-8'
     try:
         yield sys.stdout
     finally:
         sys.stdout = org
-        sys.stdout.write(captured.getvalue())
+        print(capture.getvalue())
 
 
 @contextmanager
 def control_stdin(input=None):
+    """Sends ``input`` to stdin.
+
+    >>> with control_stdin('yes'):
+    ...     input()
+    'yes'
+    """
     org = sys.stdin
     sys.stdin = StringIO(input)
-    sys.stdin.encoding = 'utf8'
+    if six.PY2:  # StringIO encoding attr isn't writable in python >= 3
+        sys.stdin.encoding = 'utf-8'
     try:
         yield sys.stdin
     finally:

--- a/tox.ini
+++ b/tox.ini
@@ -1,16 +1,20 @@
 [tox]
-envlist = beets_{1.4.1,master}, flake8
+envlist = py{27,36}-beets_{master}, py36-flake8
 
 [testenv]
-basepython = python2.7
-commands = nosetests {posargs}
+basepython =
+    py27: python2.7
+    py34: python3.4
+    py35: python3.5
+    py36: python3.6
+    py37: python3.7
+flake8_files = beetsplug test setup.py
+commands =
+    beets_{master,release}: nosetests {posargs}
+    flake8: flake8 {posargs} {[testenv]flake8_files}
 deps =
-    beets_1.4.1: beets==1.4.1
-    beets_master: git+git://github.com/sampsyo/beets.git@master
-    nose
     coverage
-
-[testenv:flake8]
-deps =
-    flake8
-commands = flake8 beetsplug test setup.py
+    nose
+    mock
+    beets_master: git+git://github.com/sampsyo/beets.git@master
+    flake8: flake8


### PR DESCRIPTION
As the title says. In particular all paths are now treated with beets' `bytestring_path`/`syspath`/`displayable_path` machinery. I hope I got it all right, this is quite large and I'm not an expert on unicode handling in beets. Types for path storage in the database should not be an issue since Python's `sqlite3` library will by default return `TEXT` columns (as are all flexible attributes) as Unicode objects across all Python versions. Nevertheless, I'd appreciate if someone (...) could upgrade beets from Python 2 to 3 and ensure that not all of the files get added to the alternative collection again (after having taken a backup, of course).

Travis and tox configs are adapted accordingly. 

Closes #18