### PR TITLE
Support format aliases from the convert plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ Change Log
 * Require at least beets v1.4.7
 * Update album art in alternatives when it changes
 * Python 3 support (Python 2.7 continuous to be supported)
+* Support the format aliases defined by the convert plugin ('wma' and 'vorbis'
+  with current beets)
 
 ## v0.8.2 - 2015-05-31
 * Fix a bug that made the plugin crash when reading unicode strings

--- a/beetsplug/alternatives.py
+++ b/beetsplug/alternatives.py
@@ -254,7 +254,8 @@ class ExternalConvert(External):
         convert_plugin = convert.ConvertPlugin()
         self._encode = convert_plugin.encode
         self._embed = convert_plugin.config['embed'].get(bool)
-        self.formats = [f.lower() for f in formats]
+        formats = [f.lower() for f in formats]
+        self.formats = [convert.ALIASES.get(f, f) for f in formats]
         self.convert_cmd, self.ext = convert.get_format(self.formats[0])
 
     def converter(self):


### PR DESCRIPTION
Allows some (two to be precise) aliases to be used in the formats config option, cf. [convert.py](https://github.com/beetbox/beets/blob/b380a4c9a37640f93b02c3277af5e76d4e8567e9/beetsplug/convert.py#L41):
```python
# Some convenient alternate names for formats.
ALIASES = {
    u'wma': u'windows media',
    u'vorbis': u'ogg',
}
```