### PR TITLE
Explicitly write tags after initial conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Change Log
 * Python 3 support (Python 2.7 continuous to be supported)
 * Support the format aliases defined by the convert plugin ('wma' and 'vorbis'
   with current beets)
+* Bugfix: Explicitly write tags after encoding instead of relying on the
+  encoder to do so
 
 ## v0.8.2 - 2015-05-31
 * Fix a bug that made the plugin crash when reading unicode strings

--- a/beetsplug/alternatives.py
+++ b/beetsplug/alternatives.py
@@ -268,6 +268,8 @@ class ExternalConvert(External):
 
             if self.should_transcode(item):
                 self._encode(self.convert_cmd, item.path, dest)
+                # Don't rely on the converter to write correct/complete tags.
+                item.write(path=dest)
             else:
                 self._log.debug(u'copying {0}'.format(displayable_path(dest)))
                 util.copy(item.path, dest, replace=True)

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -323,6 +323,21 @@ class ExternalConvertTest(TestHelper):
         item = album.items().get()
         self.assertHasEmbeddedArtwork(self.get_path(item))
 
+    def test_convert_write_tags(self):
+        item = self.add_track(myexternal='true', format='mp4', title=u'TITLE')
+
+        # We "convert" by copying the file. Setting the title simulates
+        # a badly behaved converter
+        mediafile_converted = MediaFile(syspath(item.path))
+        mediafile_converted.title = u'WRONG'
+        mediafile_converted.save()
+
+        self.runcli('alt', 'update', 'myexternal')
+        item.load()
+
+        alt_mediafile = MediaFile(syspath(self.get_path(item)))
+        self.assertEqual(alt_mediafile.title, u'TITLE')
+
     def test_skip_convert_for_same_format(self):
         item = self.add_track(myexternal='true')
         item['format'] = 'OGG'


### PR DESCRIPTION
This matches the behaviour of the convert plugin, see [its source](https://github.com/beetbox/beets/blob/b380a4c9a37640f93b02c3277af5e76d4e8567e9/beetsplug/convert.py#L319). Without this `write` call, tags in the new file can easily be be incomplete/missing: Even if the encoding program does write tags, it might not map them between formats in the way that beets would.

This was the reason behind some recent "corruption" of my alternative collection: Newly added files didn't contain any tags, not even title or artist. I did not try to check what triggered this (I hadn't changed any of beets' configuration), but I would suspect that some new release of ffmpeg changed its behaviour to not write tags anymore.

I guess it would be nice to have a test, but I'm not sure how to set it up. In some way, `ExternalConvert` would have to be mocked in order to copy the file and delete tags.