### PR TITLE
Add Python 3.7 and 3.8 to travis build matrix and tox config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,30 @@ matrix:
       python: 2.7
     - env: TOX_ENV=py27-beets_release
       python: 2.7
-    - env: TOX_ENV=py36-beets_master COVERAGE=1
+
+    - env: TOX_ENV=py36-beets_master
       python: 3.6
     - env: TOX_ENV=py36-beets_release
       python: 3.6
+
+      # xenial is required to run Python >= 3.7, cf.
+      # https://github.com/travis-ci/travis-ci/issues/9815#issuecomment-402045581
+    - env: TOX_ENV=py37-beets_master COVERAGE=1
+      python: 3.7
+      dist: xenial
+    - env: TOX_ENV=py37-beets_release
+      python: 3.7
+      dist: xenial
+
+    - env: TOX_ENV=py38-beets_master
+      python: 3.8-dev
+      dist: xenial
+      sudo: yes
+    - env: TOX_ENV=py38-beets_release
+      python: 3.8-dev
+      dist: xenial
+      sudo: yes
+
     - env: TOX_ENV=py36-flake8
       python: 3.6
 

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,7 @@ basepython =
     py35: python3.5
     py36: python3.6
     py37: python3.7
+    py38: python3.8
 flake8_files = beetsplug test setup.py
 commands =
     beets_{master,release}: nosetests {posargs}


### PR DESCRIPTION
now that beets supports them.

Actually, it might be nice to setup a [Travis cron job](https://docs.travis-ci.com/user/cron-jobs/) to regularly (say, weekly) run tests against recent beets. Does that sound good to you @geigerzaehler?