### PR TITLE
update coveralls badge to use svg and new URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ beets-alternatives
 ==================
 
 [![Build Status](https://travis-ci.org/geigerzaehler/beets-alternatives.svg?branch=master)](https://travis-ci.org/geigerzaehler/beets-alternatives)
-[![Coverage Status](https://coveralls.io/repos/geigerzaehler/beets-alternatives/badge.png?branch=master)](https://coveralls.io/r/geigerzaehler/beets-alternatives?branch=master)
+[![Coverage Status](https://coveralls.io/repos/github/geigerzaehler/beets-alternatives/badge.svg?branch=master)](https://coveralls.io/github/geigerzaehler/beets-alternatives?branch=master)
 
 You want to manage multiple versions of your audio files with beets?
 Your favorite iPlayer has limited space and does not support Ogg Vorbis? You


### PR DESCRIPTION
As the title says, I just noticed that the coveralls badge used the PNG image, which does not look very pretty next to the SVG Travis badge. Coveralls.io also thinks that there's no badge at all:

> We detected this repo isn’t badged! Grab the embed code to the right, add it to your repo to show off your code coverage, and when the badge is live hit the refresh button to remove this message. 