### PR TITLE
Fixing cli bug #35

### DIFF
--- a/beetsplug/alternatives.py
+++ b/beetsplug/alternatives.py
@@ -65,7 +65,9 @@ class AlternativesCommand(Subcommand):
 
     def __init__(self, plugin):
         parser = ArgumentParser()
-        subparsers = parser.add_subparsers()
+        subparsers = parser.add_subparsers(prog=parser.prog + ' alt')
+        subparsers.required = True
+        subparsers.dest = 'update'
         update = subparsers.add_parser('update')
         update.set_defaults(func=plugin.update)
         update.add_argument('name')


### PR DESCRIPTION
I also added the parser name as 'beet alt', by default it was `sys.argv[0]` which was only `beet`, causing help to show usage as `usage: beet update [-h] [--create] [--no-create] name` instead of `beet alt update`.