### PR TITLE
Avoid crashing 'beet completion'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 Change Log
 ==========
 
-## v0.10.0 - 2019-08-25
+## Upcoming
+* Running `beet completion` does not crash anymore [#38][]
 
+[#38]: https://github.com/geigerzaehler/beets-alternatives/issues/38
+
+## v0.10.0 - 2019-08-25
 * Symlink views now support relative symlinks (@daviddavo)
 * Running just `beet alt` does not throw an error anymore (@daviddavo)
 

--- a/beetsplug/alternatives.py
+++ b/beetsplug/alternatives.py
@@ -13,7 +13,7 @@
 
 import os.path
 import threading
-from argparse import ArgumentParser
+import argparse
 from concurrent import futures
 import six
 
@@ -82,6 +82,16 @@ class AlternativesCommand(Subcommand):
 
     def parse_args(self, args):
         return self.parser.parse_args(args), []
+
+
+class ArgumentParser(argparse.ArgumentParser):
+    """
+    Facade for ``argparse.ArgumentParser`` so that beets can call
+    `_get_all_options()` to generate shell completion.
+    """
+    def _get_all_options(self):
+        # FIXME return options like ``OptionParser._get_all_options``.
+        return []
 
 
 class External(object):

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -537,3 +537,12 @@ class ExternalRemovableTest(TestHelper):
             self.assertNotIn('Do you want to create the collection?', out)
         item.load()
         self.assertIn('alt.myexternal', item)
+
+
+class CompletionTest(TestHelper):
+    """Test invocation of ``beet completion`` with this plugin.
+
+    Only ensures that command does not fail.
+    """
+    def test_completion(self):
+        self.runcli('completion')


### PR DESCRIPTION
Add the `_get_all_options()` method to the argument parser so that `beet completion` does not throw an error anymore.

Fixes https://github.com/geigerzaehler/beets-alternatives/issues/38