### PR TITLE
Update travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,24 +21,24 @@ matrix:
 
       # xenial is required to run Python >= 3.7, cf.
       # https://github.com/travis-ci/travis-ci/issues/9815#issuecomment-402045581
-    - env: TOX_ENV=py37-beets_master COVERAGE=1
-      python: 3.7
+    - env: TOX_ENV=py38-beets_master COVERAGE=1
+      python: 3.8
       dist: xenial
-    - env: TOX_ENV=py37-beets_release
-      python: 3.7
-      dist: xenial
-
-    - env: TOX_ENV=py38-beets_master
-      python: 3.8-dev
-      dist: xenial
-      sudo: yes
     - env: TOX_ENV=py38-beets_release
-      python: 3.8-dev
+      python: 3.8
+      dist: xenial
+
+    - env: TOX_ENV=py39-beets_master
+      python: 3.9-dev
+      dist: xenial
+      sudo: yes
+    - env: TOX_ENV=py39-beets_release
+      python: 3.9-dev
       dist: xenial
       sudo: yes
 
-    - env: TOX_ENV=py36-flake8
-      python: 3.6
+    - env: TOX_ENV=py38-flake8
+      python: 3.8
 
 install:
   - "pip install tox"

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,23 +19,15 @@ matrix:
     - env: TOX_ENV=py36-beets_release
       python: 3.6
 
-      # xenial is required to run Python >= 3.7, cf.
-      # https://github.com/travis-ci/travis-ci/issues/9815#issuecomment-402045581
     - env: TOX_ENV=py38-beets_master COVERAGE=1
       python: 3.8
-      dist: xenial
     - env: TOX_ENV=py38-beets_release
       python: 3.8
-      dist: xenial
 
     - env: TOX_ENV=py39-beets_master
       python: 3.9-dev
-      dist: xenial
-      sudo: yes
     - env: TOX_ENV=py39-beets_release
       python: 3.9-dev
-      dist: xenial
-      sudo: yes
 
     - env: TOX_ENV=py38-flake8
       python: 3.8

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,8 +1,8 @@
-[nosetests]
-verbosity=1
-with-coverage=1
-cover-erase=1
-cover-package=beetsplug.alternatives
-cover-html=1
-cover-html-dir=coverage
-logging-clear-handlers=1
+[coverage:run]
+source = beetsplug.alternatives
+
+[coverage:html]
+directory = coverage
+
+[tool:pytest]
+addopts = --cov --cov-report=term --cov-report=html

--- a/setup.py
+++ b/setup.py
@@ -34,5 +34,6 @@ setup(
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -12,11 +12,12 @@ basepython =
     py39: python3.9
 flake8_files = beetsplug test setup.py
 commands =
-    beets_{master,release}: nosetests {posargs}
+    beets_{master,release}: pytest {posargs}
     flake8: flake8 {posargs} {[testenv]flake8_files}
 deps =
     coverage
-    nose
+    pytest
+    pytest-cov
     mock
     beets_master: git+git://github.com/sampsyo/beets.git@master
     flake8: flake8

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,36}-beets_{master}, py36-flake8
+envlist = py{27,38}-beets_{master}, py38-flake8
 
 [testenv]
 basepython =
@@ -9,6 +9,7 @@ basepython =
     py36: python3.6
     py37: python3.7
     py38: python3.8
+    py39: python3.9
 flake8_files = beetsplug test setup.py
 commands =
     beets_{master,release}: nosetests {posargs}


### PR DESCRIPTION
- Bump python versions
- travis appears to use Xenial everywhere nowadays, so no need to force this distribution in order to get recent Python
- the `sudo` keyword was deprecated because travis now uses a fully virtualized infrastructure: [link](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration#timeline---its-happening-fast)