### PR TITLE
SymlinkView: Fix symlink removal (fixes #47)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ Change Log
 
 ## Upcoming
 * Add `beet alt list-tracks` command
+* SymlinkView: Fix stale symlinks not being removed when files are moved in the
+  main library [#47][]
+
+[#47]: https://github.com/geigerzaehler/beets-alternatives/issues/47
 
 ## v0.10.1 - 2019-09-18
 * Running `beet completion` does not crash anymore [#38][]

--- a/beetsplug/alternatives.py
+++ b/beetsplug/alternatives.py
@@ -186,7 +186,7 @@ class External(object):
 
     def matched_item_action(self, item):
         path = self.get_path(item)
-        if path and os.path.isfile(syspath(path)):
+        if path and os.path.lexists(syspath(path)):
             dest = self.destination(item)
             _, path_ext = os.path.splitext(path)
             _, dest_ext = os.path.splitext(dest)

--- a/beetsplug/alternatives.py
+++ b/beetsplug/alternatives.py
@@ -390,6 +390,10 @@ class SymlinkView(External):
             if self.relativelinks == self.LINK_RELATIVE else item.path)
         util.link(link, dest)
 
+    def sync_art(self, item, path):
+        # FIXME: symlink art
+        pass
+
 
 class Worker(futures.ThreadPoolExecutor):
 


### PR DESCRIPTION
The first commit implements a test for the scenario from #47. The others fix it:
- beets' `util.remove(path, soft=True)` is always a no-op for symlinks...
- separate the logic for detecting changes for `External`/`ExternalConvert` collections and `SymlinkView`s since they have somewhat different semantics.

**Todo:** add unit tests for `_remove` and `_samelink`, update changelog.

Closes #47 