### PR TITLE
specify encoding to fix importing the plugin on Python 2

### DIFF
--- a/beetsplug/alternatives.py
+++ b/beetsplug/alternatives.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2014 Thomas Scholtes
+# -*- coding: utf-8 -*-
 
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"), to


### PR DESCRIPTION
See https://github.com/geigerzaehler/beets-alternatives/pull/48#issuecomment-602186433 : So long as Python 2 is not entirely burried, we might want to specify the source encoding explicitly. Related: [PEP 263](https://www.python.org/dev/peps/pep-0263/).