### PR TITLE
Remove beets 1.4.9 and Python 3.9 from CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,9 @@ matrix:
     - env: TOX_ENV=py38-flake8
       python: 3.8
 
+  allow_failures:
+    - python: 3.9-dev
+
 install:
   - "pip install tox"
   - "[ ! -z $COVERAGE ] && pip install coveralls || true"


### PR DESCRIPTION
Beets 1.4.9 is not compatible with Python 3.9. We remove it from the CI build matrix.