### PR TITLE
Update tox and travis config for Python 3.10 alpha

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,16 +24,16 @@ matrix:
     - env: TOX_ENV=py38-beets_release
       python: 3.8
 
-    - env: TOX_ENV=py39-beets_master
-      python: 3.9-dev
-    - env: TOX_ENV=py39-beets_release
-      python: 3.9-dev
+    - env: TOX_ENV=py310-beets_master
+      python: 3.10-dev
+    - env: TOX_ENV=py310-beets_release
+      python: 3.10-dev
 
     - env: TOX_ENV=py38-flake8
       python: 3.8
 
   allow_failures:
-    - python: 3.9-dev
+    - python: 3.10-dev
 
 install:
   - "pip install tox"

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,7 @@ basepython =
     py37: python3.7
     py38: python3.8
     py39: python3.9
+    py310: python3.10
 flake8_files = beetsplug test setup.py
 commands =
     beets_{master,release}: pytest {posargs}


### PR DESCRIPTION
Python 3.10 should have arrived on Travis, let's see whether it succeeds. I kept the default at 3.8, that's probably still more common than the very new 3.9.