### PR TITLE
Respect convert's threads configuration

### DIFF
--- a/beetsplug/alternatives.py
+++ b/beetsplug/alternatives.py
@@ -161,7 +161,7 @@ class External(object):
         self.name = name
         self.lib = lib
         self.path_key = "alt.{0}".format(name)
-        self.max_workers = int(str(beets.config['convert']['threads']))
+        self.max_workers = int(str(beets.config["convert"]["threads"]))
         self.parse_config(config)
 
     def parse_config(self, config):

--- a/beetsplug/alternatives.py
+++ b/beetsplug/alternatives.py
@@ -162,6 +162,7 @@ class External(object):
         self.name = name
         self.lib = lib
         self.path_key = "alt.{0}".format(name)
+        self.max_workers = int(str(beets.config['convert']['threads']))
         self.parse_config(config)
 
     def parse_config(self, config):
@@ -364,7 +365,7 @@ class ExternalConvert(External):
                 self.sync_art(item, dest)
             return item, dest
 
-        return Worker(_convert)
+        return Worker(_convert, self.max_workers)
 
     def destination(self, item):
         dest = super(ExternalConvert, self).destination(item)

--- a/beetsplug/alternatives.py
+++ b/beetsplug/alternatives.py
@@ -27,7 +27,6 @@ from beets.ui import Subcommand, UserError, decargs, get_path_formats, input_yn,
 from beets.util import (
     FilesystemError,
     bytestring_path,
-    cpu_count,
     displayable_path,
     syspath,
 )
@@ -451,8 +450,8 @@ class SymlinkView(External):
 
 
 class Worker(futures.ThreadPoolExecutor):
-    def __init__(self, fn, max_workers=None):
-        super(Worker, self).__init__(max_workers or cpu_count())
+    def __init__(self, fn, max_workers):
+        super(Worker, self).__init__(max_workers)
         self._tasks = set()
         self._fn = fn
 

--- a/beetsplug/alternatives.py
+++ b/beetsplug/alternatives.py
@@ -24,12 +24,7 @@ from beets import art, util
 from beets.library import Item, parse_query_string
 from beets.plugins import BeetsPlugin
 from beets.ui import Subcommand, UserError, decargs, get_path_formats, input_yn, print_
-from beets.util import (
-    FilesystemError,
-    bytestring_path,
-    displayable_path,
-    syspath,
-)
+from beets.util import FilesystemError, bytestring_path, displayable_path, syspath
 
 from beetsplug import convert
 

--- a/beetsplug/alternatives.py
+++ b/beetsplug/alternatives.py
@@ -321,7 +321,7 @@ class External(object):
             util.copy(item.path, dest, replace=True)
             return item, dest
 
-        return Worker(_convert)
+        return Worker(_convert, self.max_workers)
 
     def sync_art(self, item, path):
         """Embed artwork in the destination file."""


### PR DESCRIPTION
Small PR that adds support for respecting `convert`'s `threads` config. https://github.com/geigerzaehler/beets-alternatives/issues/41.

I didn't write any tests so that's now awesome but Works on My Machine™. 

The code located [here](https://github.com/geigerzaehler/beets-alternatives/blob/master/beetsplug/alternatives.py#L454) is probably also not needed or could be refactored to remove setting threads to CPU count since that should already be done via the `convert` plugin.