### PR TITLE
Continue other builds if Python preview build fails

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -12,6 +12,7 @@ jobs:
         - "3.12-dev" # next
 
     runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.python-version == '3.12-dev' }}
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
The build against the preview version of Python may fail. In this case we allow the other builds to proceed.