### PR TITLE
Confirm support for beets v2

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -45,8 +45,13 @@ jobs:
         # Ignore .coverage, which has limited support from coveralls
         file: coverage.xml
 
-  build-beets-master:
+  build-beets-versions:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        beets:
+          - "git+https://github.com/beetbox/beets#master"
+          - "beets==1.6.1"
 
     steps:
     - uses: actions/checkout@v4
@@ -57,7 +62,6 @@ jobs:
         cache: poetry
     - run: poetry env use $(which python)
     - run: poetry install
-    # We cannot use `poetry add` because poetry does not install beets
-    # dependencies properly
-    - run: poetry run pip install "git+https://github.com/beetbox/beets#master"
+    - run: poetry add ${{ matrix.beets }}
+    - run: poetry run pyright --warnings
     - run: poetry run pytest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Change Log
 ## Upcoming
 * Fix an issue where items in a symlink collection with relative links were
   always unnecessarily updated.
+* Support [Beets v2](https://beets.readthedocs.io/en/latest/changelog.html#may-30-2024)
 
 ## v0.11.1 - 2024-04-24
 * Add `--all` flag to update command which will update all configured

--- a/poetry.lock
+++ b/poetry.lock
@@ -2,13 +2,13 @@
 
 [[package]]
 name = "beets"
-version = "1.6.1"
+version = "2.0.0"
 description = "music tagger and library organizer"
 optional = false
 python-versions = "*"
 files = [
-    {file = "beets-1.6.1-py3-none-any.whl", hash = "sha256:1cb28c694a634d33f1a2e218a9701d962d980d317fa7e43721a42e2835ba6a0e"},
-    {file = "beets-1.6.1.tar.gz", hash = "sha256:cab2d89fc27a6013ca17a3060e1bf46f3d7aabeadc5aa9365df6a38c519f0224"},
+    {file = "beets-2.0.0-py3-none-any.whl", hash = "sha256:6fe596f578ce50652fc634d399af67bc0450b325c349989af781805599fcedb3"},
+    {file = "beets-2.0.0.tar.gz", hash = "sha256:3b1172b5bc3729e33a6ea4689f7d0236682bf828c67196b6a260f0389cb1f8cf"},
 ]
 
 [package.dependencies]
@@ -596,4 +596,4 @@ test = ["big-O", "importlib-resources", "jaraco.functools", "jaraco.itertools", 
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8.1"
-content-hash = "c84488872e66c86a0f87b293b0016e2b3a603432f994cb632f2c82fe5336b95f"
+content-hash = "95816879ef85bc59966de3161801dcda5c7534402b8958ea38e83f7a784858db"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = "^3.8.1"
-beets = "^1.6.0"
+beets = ">=1.6.0 <3"
 
 [tool.poetry.group.dev.dependencies]
 confuse = "^2.0.1"


### PR DESCRIPTION
Allow beets v2 as dependency, use it in the lockfile and add a build against v1.6.1