### PR TITLE
Use pathlib instead of beets's path handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Change Log
 ==========
 
+## Upcoming
+* Consistently use Unicode paths to alternative items. This may result and
+  collection updates and orphaned files in alternatives. It may also improve
+  usability on non-standard file systems (see [#74]).
+
+[#74]: https://github.com/geigerzaehler/beets-alternatives/issues/74
+
 ## v0.12.0 - 2024-06-25
 * Fix an issue where items in a symlink collection with relative links were
   always unnecessarily updated.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,7 @@ preview = true
 extend-select = [
   "I",    # Sort imports
   "C",    # Pyflakes conventions
+  "PTH",  # Use pathlib instead of os
   "PIE",  # Misc. lints
   "UP",   # Enforce modern Python syntax
   "FURB", # Also enforce more modern Python syntax

--- a/test/helper.py
+++ b/test/helper.py
@@ -215,16 +215,16 @@ class TestHelper:
 class MockedWorker(alternatives.Worker):
     def __init__(
         self,
-        fn: Callable[[Item], Tuple[Item, bytes]],
+        fn: Callable[[Item], Tuple[Item, Path]],
         max_workers: Optional[int] = None,
     ):
         # Don’t call `super().__init__()`. We don’t want to start the
         # ThreadPoolExecutor.
-        self._tasks: Set[futures.Future[Tuple[Item, bytes]]] = set()
+        self._tasks: Set[futures.Future[Tuple[Item, Path]]] = set()
         self._fn = fn
 
     def run(self, item: Item):
-        fut: futures.Future[tuple[Item, bytes]] = futures.Future()
+        fut: futures.Future[tuple[Item, Path]] = futures.Future()
         res = self._fn(item)
         fut.set_result(res)
         self._tasks.add(fut)


### PR DESCRIPTION
Internally, all paths are represented by `Path` instances instead of `bytes`. When we pass paths to beets code (`Item.write`, `beets.art.embed_item`) we explicitly convert it to `bytes`.

We replace the following beets utility functions with standard library versions that handle `Path`s.

- `beets.util.mkdirall` -> `Path.mkdir`
- `beets.util.link` -> `Path.symlink_to`
- `beets.util.copy` -> `shutil.copfyile`
- `beets.util.samefile` -> `Path.__eq__ `