### PR TITLE
Add maxwidth setting for album art

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,12 @@ following settings.
 
   By default no transcoding is done.
 
+* **`albumart_maxwidth`** Downscale the embedded album art to a width
+  of maximum `albumart_maxwidth` pixels. The aspect ratio of the image
+  will be preserved. This is comparable to the setting with the same
+  name of the [convert plugin][convert plugin]. 
+
+
 * **`removable`** If this is `true` (the default) and `directory` does
   not exist, the `update` command will ask you to confirm the creation
   of the external collection. (optional)

--- a/beetsplug/alternatives.py
+++ b/beetsplug/alternatives.py
@@ -181,6 +181,7 @@ class External:
         self.query, _ = parse_query_string(query, Item)
 
         self.removable = config.get(dict).get("removable", True)  # type: ignore
+        self.album_art_maxwidth = config.get(dict).get("album_art_maxwidth", None)  # type: ignore
 
         if "directory" in config:
             dir = config["directory"].as_path()
@@ -342,7 +343,14 @@ class External:
         album = item.get_album()
         if album and album.artpath and Path(str(album.artpath, "utf8")).is_file():
             self._log.debug(f"Embedding art from {album.artpath} into {path}")
-            art.embed_item(self._log, item, album.artpath, itempath=bytes(path))
+
+            art.embed_item(
+                self._log,
+                item,
+                album.artpath,
+                maxwidth=self.album_art_maxwidth,
+                itempath=bytes(path),
+            )
 
 
 class ExternalConvert(External):


### PR DESCRIPTION
This allows setting `album_art_maxwidth` (same setting name as in the convert plugin) to restrict the maximum size of the embedded album art.