### PR TITLE
Workaround pyright and mixed namepspaced packages

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -69,6 +69,11 @@ jobs:
     - run: poetry env use "$(which python)"
     - run: poetry install
     - run: poetry add ${{ matrix.beets }}
-    - run: poetry run pyright --warnings
     - run: sudo apt-get install -y imagemagick
     - run: poetry run pytest
+    - if: contains(matrix.beets, 'master')
+      # Beets does not require this file anymore since https://github.com/beetbox/beets/commit/916d40f
+      # And if we keep the file around pyright can’t resolve the
+      # `beetsplug.convert` module correctly
+      run: rm beetsplug/__init__.py
+    - run: poetry run pyright --warnings


### PR DESCRIPTION
This is not necessary since https://github.com/beetbox/beets/commit/916d40f86fadcd8bd52ee72c2db67f90a3e75619