### PR TITLE
Add per-alternative replace config

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,11 @@ following settings.
   ImageMagick estimates input quality (using 92 if unknown), PIL uses 75.
   Default: 0 (disabled) (optional)
 
+* **`replace`** A map of regular expression patterns to replacement strings,
+  applied to destination file paths within this collection. Configured like
+  the global beets [`replace`][config-replace] setting but scoped to this
+  collection. (optional)
+
 Events
 ------
 
@@ -365,3 +370,4 @@ SOFTWARE.
 [using plugins]: http://beets.readthedocs.org/en/latest/plugins/index.html#using-plugins
 [cover formats]: https://beets.readthedocs.io/en/stable/plugins/fetchart.html#image-formats
 [art_filename]: https://beets.readthedocs.io/en/stable/reference/config.html#art-filename
+[config-replace]: https://beets.readthedocs.io/en/stable/reference/config.html#replace

--- a/beetsplug/alternatives.py
+++ b/beetsplug/alternatives.py
@@ -14,6 +14,7 @@ import argparse
 import logging
 import os.path
 import queue
+import re
 import shutil
 from collections.abc import Callable, Iterator, Sequence
 from concurrent import futures
@@ -187,11 +188,13 @@ class Config:
     """If enabled forced album art to be converted to specified format for the collection. Most often, this will be either JPEG or PNG."""
 
     album_art_deinterlace: bool
-    """If enabled, Pillow or ImageMagick backends are instructed to store cover art as non-progressive JPEG. 
+    """If enabled, Pillow or ImageMagick backends are instructed to store cover art as non-progressive JPEG.
     You might need this if you use DAPs that don’t support progressive images. Default: no."""
 
     album_art_quality: int
     """JPEG Quality for album art if it is resized. Default: 0"""
+
+    replacements: list[tuple[re.Pattern[str], str]] | None
 
     def __init__(self, collection_id: str, config: confuse.ConfigView, lib: Library):
         self.collection_id = collection_id
@@ -256,6 +259,16 @@ class Config:
         )
         assert isinstance(album_art_quality, int)
         self.album_art_quality = album_art_quality
+
+        if "replace" in config:
+            try:
+                self.replacements = get_replacements(config["replace"])
+            except UserError as exc:
+                raise UserError(
+                    f"Error in alternatives.{self.collection_id}.replace: {exc}"
+                ) from exc
+        else:
+            self.replacements = None
 
         if "directory" in config:
             dir = config["directory"].as_path()
@@ -535,6 +548,8 @@ class External:
         path = item.destination(
             path_formats=self._config.path_formats, relative_to_libdir=True
         ).decode("utf-8")
+        if self._config.replacements:
+            path = util.sanitize_path(path, self._config.replacements)
         assert isinstance(path, str)
         return self._config.directory / path
 
@@ -747,3 +762,23 @@ def _send_item_updated(*, collection: str, path: Path, item: Item, action: Actio
         item=item,
         action=action.value,
     )
+
+
+def get_replacements(
+    replace_config: confuse.ConfigView,
+) -> list[tuple[re.Pattern[str], str]]:
+    """Read regex/string replacement pairs from a confuse config view.
+
+    Adapted from beets' own `get_replacements` in `beets.ui`, which reads
+    from the global config. This version accepts an arbitrary config view.
+    """
+    replacements = []
+    for pattern, repl in replace_config.get(dict).items():  # type: ignore[arg-type]
+        repl = repl or ""
+        try:
+            replacements.append((re.compile(pattern), repl))
+        except (re.error, TypeError) as e:
+            raise UserError(
+                f"malformed regular expression in replace: {pattern}"
+            ) from e
+    return replacements

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -74,7 +74,11 @@ class TestDoc(TestHelper):
         list_output = self.runcli(
             "alt", "list-tracks", "myplayer", "--format", "$artist $title"
         )
-        assert list_output == "Bach was mp3\nBach was m4a\nBach was ogg\n"
+        assert sorted(list_output.splitlines()) == [
+            "Bach was m4a",
+            "Bach was mp3",
+            "Bach was ogg",
+        ]
 
         self.runcli("alt", "update", "myplayer")
         mediafile = MediaFile(external_from_ogg)
@@ -109,7 +113,12 @@ class TestSymlinkView(TestHelper):
             "by-year": {
                 "paths": {"default": "$year/$album/$title"},
                 "formats": "link",
-            }
+            },
+            "by-year-replaced": {
+                "paths": {"default": "$year/$album/$title"},
+                "replace": {"-": "_"},
+                "formats": "link",
+            },
         }
         self.alt_config = self.config["alternatives"]["by-year"]
 
@@ -215,6 +224,80 @@ class TestSymlinkView(TestHelper):
         # Symlink is created
         assert album.artpath
         assert_symlink(external_art_path, Path(str(album.artpath, "utf8")))
+
+    def test_add_album_replaced(self):
+        """Test the symlinks are created with replacements applied
+        * An album is added
+        * Links are created with expected replaced paths
+        """
+        self.add_album(
+            artist="Michael Jackson",
+            album="Thriller-Something",
+            year="1990",
+            original_year="1982",
+        )
+
+        self.runcli("alt", "update", "by-year-replaced")
+
+        by_year_path = (
+            self.libdir / "by-year-replaced/1990/Thriller_Something/track 1.mp3"
+        )
+        assert_symlink(
+            link=by_year_path,
+            target=self.libdir / "Michael Jackson/Thriller-Something/track 1.mp3",
+            absolute=True,
+        )
+
+    def test_add_album_replaced_regex(self):
+        """Replacements using actual regex patterns are applied correctly."""
+        self.config["alternatives"]["by-year-replaced"]["replace"] = {"[aeiou]": "_"}
+        self.add_album(
+            artist="Michael Jackson",
+            album="Thriller-Something",
+            year="1990",
+            original_year="1982",
+        )
+
+        self.runcli("alt", "update", "by-year-replaced")
+
+        by_year_path = (
+            self.libdir / "by-year-replaced/1990/Thr_ll_r-S_m_th_ng/tr_ck 1.mp3"
+        )
+        assert_symlink(
+            link=by_year_path,
+            target=self.libdir / "Michael Jackson/Thriller-Something/track 1.mp3",
+            absolute=True,
+        )
+
+    def test_add_album_replaced_multiple(self):
+        """Multiple replacement pairs are all applied."""
+        self.config["alternatives"]["by-year-replaced"]["replace"] = {
+            "-": "_",
+            "r": "R",
+        }
+        self.add_album(
+            artist="Michael Jackson",
+            album="Thriller-Something",
+            year="1990",
+            original_year="1982",
+        )
+
+        self.runcli("alt", "update", "by-year-replaced")
+
+        by_year_path = (
+            self.libdir / "by-year-replaced/1990/ThRilleR_Something/tRack 1.mp3"
+        )
+        assert_symlink(
+            link=by_year_path,
+            target=self.libdir / "Michael Jackson/Thriller-Something/track 1.mp3",
+            absolute=True,
+        )
+
+    def test_malformed_replace_regex(self):
+        """A malformed regex in the replace config raises a UserError."""
+        self.config["alternatives"]["by-year-replaced"]["replace"] = {"[invalid": "_"}
+        with pytest.raises(UserError, match="malformed regular expression"):
+            self.runcli("alt", "update", "by-year-replaced")
 
 
 class TestExternalCopy(TestHelper):


### PR DESCRIPTION
Each alternative can now specify a `replace` block, which works like beets' global `replace` config (regex/string pairs applied to avoid filesystem-incompatible characters), but supplements the global replacements rather than overriding them.

This is useful if there are differing filesystem limitations for the ultimate destination of the alternative file tree than there are for the library itself.