### PR TITLE
Don't require the `convert` plugin to be enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## Upcoming
+
+- Don't require the `convert` plugin to be enabled.
+
 ## v0.14.2 - 2026-06-24
 
 - Ensure tests pass with beets v2.12

--- a/beetsplug/alternatives.py
+++ b/beetsplug/alternatives.py
@@ -318,7 +318,11 @@ class External:
         self._config = config
         self.lib = lib
         self.path_key = f"alt.{config.collection_id}"
-        self.max_workers = int(str(beets.config["convert"]["threads"]))
+        threads = beets.config["convert"]["threads"].get(
+            confuse.Optional(confuse.Integer(), default=os.cpu_count() or 1)
+        )
+        assert isinstance(threads, int)
+        self.max_workers = threads
 
     def item_change_actions(
         self, item: Item, actual: Path, dest: Path

--- a/test/helper.py
+++ b/test/helper.py
@@ -12,7 +12,6 @@ from zlib import crc32
 import beets
 import beets.library
 import beets.plugins
-import beetsplug.convert
 import beetsplug.hook
 import pytest
 from beets import logging, ui
@@ -177,7 +176,6 @@ class TestHelper:
 
         beets.plugins._instances = [
             beetsplug.alternatives.AlternativesPlugin(),
-            beetsplug.convert.ConvertPlugin(),
             beetsplug.hook.HookPlugin(),
             self._lib_tracker,
         ]


### PR DESCRIPTION
Fixes #238
