### PR TITLE
Read Embedded Cover Art in Main Collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,8 +93,8 @@ if the device is not mounted. Since this is our first go, we answer the
 question with yes.
 
 The command will copy all files with the artist ‘Bach’ and format either ‘AAC’
-or ‘MP3’ to the `/player` directory. All other formats will be transcodec to the
-‘AAC’ format unsing the [*convert* plugin][convert plugin]. The transcoding
+or ‘MP3’ to the `/player` directory. All other formats will be transcoded to the
+‘AAC’ format using the [*convert* plugin][convert plugin]. The transcoding
 process can be configured through [*convert’s* configuration][convert config].
 
 If you update some tracks in your main collection, the `alt update`
@@ -107,7 +107,7 @@ beet modify composer="Johann Sebastian Bach" artist:Bach
 beet alt update myplayer
 ```
 
-After going for a run you mitght realize that Bach is probably not the
+After going for a run you might realize that Bach is probably not the
 right thing to work out to. So you decide to put Beethoven on your
 player.
 
@@ -249,7 +249,7 @@ following settings.
   audio file formats in the external collection. If the ‘format’ field
   of a track is included in the list, the file is copied. Otherwise,
   the file is transcoded to the first format in the list. The name of
-  the first format must correpond to a key in the
+  the first format must correspond to a key in the
   [`convert.formats`][convert plugin] configuration. This configuration
   controls the transcoding process.
 
@@ -266,11 +266,23 @@ following settings.
   **`formats`** is `link`, it sets the type of links to create. For
   differences between link types and examples see [Symlink Views](#symlink-views).
 
-* **`album_art_embed`** Embed album art into the media file. Default `yes`
+* **`album_art_embed`** If this is `true` (the default), embed album art into
+  the media file. If `false`, any embedded album art will be stripped from the
+  files in the external collection.
 
 * **`album_art_copy`** Copy album art files into the collection. If
   `formats: link` is used then album art is linked instead. Filename for
   cover art is determined by the [art_filename][art_filename] option.
+
+* **`album_art_source`** Controls which art source to prefer when syncing album
+  art. Applies to both embedding art into audio files (`album_art_embed`) and
+  copying art as separate files (`album_art_copy`). The plugin will extract
+  embedded art and save it as files if needed. Options:
+  - `embedded` (default): Prefer embedded art from source files, fallback to
+    external art file
+  - `external`: Prefer external art files, fallback to embedded art
+  - `embedded-only`: Only use embedded art from source files
+  - `external-only`: Only use external art files
 
 * **`album_art_maxwidth`** If set, resize album art to this maximum width while
   preserving aspect ratio. Comparable to the [convert plugin][convert plugin]

--- a/README.md
+++ b/README.md
@@ -284,6 +284,12 @@ following settings.
   - `embedded-only`: Only use embedded art from source files
   - `external-only`: Only use external art files
 
+* **`album_art_different_embedded_prompt`** If true (the default), prompt the user
+  when tracks in the same album have different embedded art (including tracks
+  missing embedded art). The user can confirm using the first track's art or abort
+  the update. If false, silently use the first track's art without prompting.
+  Default: yes.
+
 * **`album_art_maxwidth`** If set, resize album art to this maximum width while
   preserving aspect ratio. Comparable to the [convert plugin][convert plugin]
   setting with the same name.

--- a/beetsplug/alternatives.py
+++ b/beetsplug/alternatives.py
@@ -20,6 +20,7 @@ from concurrent import futures
 from enum import Enum
 from pathlib import Path
 from typing import Literal, TypeVar
+from zlib import crc32
 
 import beets
 import beets.plugins
@@ -219,6 +220,12 @@ class Config:
     - `external-only`: only use external art files
     Default: `embedded`."""
 
+    album_art_different_embedded_prompt: bool
+    """If true, ask user when tracks in the same album have different embedded art
+    (including missing art) to confirm using the first track's art. If user declines,
+    the update is aborted. If false, silently use the first track's art without
+    prompting. Default: yes."""
+
     album_art_maxwidth: int | None
     """Maximum width of embedded album art. Larger art is resized."""
 
@@ -280,6 +287,12 @@ class Config:
         )
         assert isinstance(album_art_source_str, str)
         self.album_art_source = AlbumArtSource(album_art_source_str)
+
+        album_art_different_embedded_prompt = config["album_art_different_embedded_prompt"].get(
+            confuse.TypeTemplate(bool, default=True)
+        )
+        assert isinstance(album_art_different_embedded_prompt, bool)
+        self.album_art_different_embedded_prompt = album_art_different_embedded_prompt
 
         album_art_maxwidth = config["album_art_maxwidth"].get(
             confuse.Optional(confuse.Integer())
@@ -442,6 +455,16 @@ class External:
         )
         return input_yn(msg, require=True)
 
+    def ask_use_first_embedded_art(self, album_name: str) -> bool:
+        if not self._config.album_art_different_embedded_prompt:
+            return True
+
+        msg = (
+            f"Album '{album_name}' has tracks with different embedded art. "
+            "Use first art found? (y/n)"
+        )
+        return input_yn(msg, require=True)
+
     def update(self, create: bool | None = None):  # noqa: C901
         if not self._config.directory.is_dir() and not self.ask_create(create):
             print_(f"Skipping creation of {self._config.directory}")
@@ -583,7 +606,7 @@ class External:
 
             print_(f"~{dest}")
 
-    def _get_art_for_album(self, album: Album, link: bool = False) -> Path | None:
+    def _get_art_for_album(self, album: Album, link: bool = False) -> Path | None:  # noqa: C901
         """Get art for an album based on album_art_source preference.
 
         Returns the path to the art file to use, or None if no art should be copied.
@@ -602,9 +625,37 @@ class External:
         if not link:  # Don't try to extract embedded for symlinks
             items = album.items()
             if items:
-                embedded_art_bytes = self._extract_embedded_art(items[0])
-                if embedded_art_bytes:
-                    embedded_art = Path(str(embedded_art_bytes, "utf8"))
+                # Check if all items have the same embedded art. If items have
+                # different art or some are missing art, use the first one if
+                # there is one.
+                has_different = False
+                first_crc = None
+                first_valid_index = None
+                for i, item in enumerate(items):
+                    mf = MediaFile(str(item.path, "utf8"))
+                    art_crc = crc32(mf.art) if mf.art else None
+                    if first_valid_index is None and art_crc is not None:
+                        first_valid_index = i
+                    if i == 0:
+                        first_crc = art_crc
+                    elif first_crc != art_crc:
+                        has_different = True
+                    if has_different and first_valid_index is not None:
+                        break
+                use_embedded = True
+                if has_different:
+                    album_name = f"{album.albumartist} - {album.album}"
+                    use_embedded = self.ask_use_first_embedded_art(album_name)
+                    if not use_embedded:
+                        raise UserError(
+                            f"Update cancelled by user (different embedded art in "
+                            f"'{album_name}')"
+                        )
+
+                if use_embedded and first_valid_index is not None:
+                    embedded_art_bytes = self._extract_embedded_art(items[first_valid_index])
+                    if embedded_art_bytes:
+                        embedded_art = Path(str(embedded_art_bytes, "utf8"))
 
         # Choose which art to use based on preference
         if source_pref == AlbumArtSource.EMBEDDED:

--- a/beetsplug/alternatives.py
+++ b/beetsplug/alternatives.py
@@ -30,6 +30,7 @@ from beets.plugins import BeetsPlugin
 from beets.ui import Subcommand, input_yn, print_
 from beets.util.artresizer import ArtResizer
 from beets.util.functemplate import Template
+from mediafile import MediaFile
 from typing_extensions import Never, override
 
 # beets master moved these out of `beets.ui`; fall back for the 2.11.0 release.
@@ -167,6 +168,22 @@ class ArgumentParser(argparse.ArgumentParser):
         return []
 
 
+class AlbumArtSource(Enum):
+    """Source preference for album art."""
+
+    #: Prefer embedded art from source files, fallback to external art file
+    EMBEDDED = "embedded"
+
+    #: Prefer external art files, fallback to embedded art
+    EXTERNAL = "external"
+
+    #: Only use embedded art from source files
+    EMBEDDED_ONLY = "embedded-only"
+
+    #: Only use external art files
+    EXTERNAL_ONLY = "external-only"
+
+
 class Config:
     collection_id: str
 
@@ -194,6 +211,14 @@ class Config:
     album_art_copy: bool
     """Copy or symlink album art to collection"""
 
+    album_art_source: AlbumArtSource
+    """Source to prefer for album art when embedding. Options:
+    - `embedded`: prefer embedded art from source files, fallback to external art file
+    - `external`: prefer external art files, fallback to embedded art
+    - `embedded-only`: only use embedded art from source files
+    - `external-only`: only use external art files
+    Default: `embedded`."""
+
     album_art_maxwidth: int | None
     """Maximum width of embedded album art. Larger art is resized."""
 
@@ -201,7 +226,7 @@ class Config:
     """If enabled forced album art to be converted to specified format for the collection. Most often, this will be either JPEG or PNG."""
 
     album_art_deinterlace: bool
-    """If enabled, Pillow or ImageMagick backends are instructed to store cover art as non-progressive JPEG. 
+    """If enabled, Pillow or ImageMagick backends are instructed to store cover art as non-progressive JPEG.
     You might need this if you use DAPs that don’t support progressive images. Default: no."""
 
     album_art_quality: int
@@ -246,6 +271,15 @@ class Config:
         )
         assert isinstance(album_art_copy, bool)
         self.album_art_copy = album_art_copy
+
+        album_art_source_str = config["album_art_source"].get(
+            confuse.Choice(
+                {source.value: source.value for source in AlbumArtSource},
+                default=AlbumArtSource.EMBEDDED.value,
+            )
+        )
+        assert isinstance(album_art_source_str, str)
+        self.album_art_source = AlbumArtSource(album_art_source_str)
 
         album_art_maxwidth = config["album_art_maxwidth"].get(
             confuse.Optional(confuse.Integer())
@@ -324,6 +358,32 @@ class External:
         assert isinstance(threads, int)
         self.max_workers = threads
 
+    def _should_embed_art(self, item: Item, actual: Path) -> bool:
+        if not self._config.album_art_embed:
+            return False
+
+        item_mtime_alt = actual.stat().st_mtime
+        source_is_newer = item_mtime_alt < Path(str(item.path, "utf8")).stat().st_mtime
+        source_has_art = source_is_newer and self._has_embedded_art(item)
+
+        album = item.get_album()
+        external_is_newer = bool(
+            album
+            and album.artpath
+            and Path(str(album.artpath, "utf8")).is_file()
+            and (item_mtime_alt < Path(str(album.artpath, "utf8")).stat().st_mtime)
+        )
+
+        source_pref = self._config.album_art_source
+        if source_pref == AlbumArtSource.EMBEDDED:
+            return source_has_art or external_is_newer
+        elif source_pref == AlbumArtSource.EXTERNAL:
+            return external_is_newer or source_has_art
+        elif source_pref == AlbumArtSource.EMBEDDED_ONLY:
+            return source_has_art
+        else:  # EXTERNAL_ONLY
+            return external_is_newer
+
     def item_change_actions(
         self, item: Item, actual: Path, dest: Path
     ) -> Sequence[Action]:
@@ -338,15 +398,8 @@ class External:
         item_mtime_alt = actual.stat().st_mtime
         if item_mtime_alt < Path(str(item.path, "utf8")).stat().st_mtime:
             actions.append(Action.WRITE)
-        album = item.get_album()
 
-        if (
-            self._config.album_art_embed
-            and album
-            and album.artpath
-            and Path(str(album.artpath, "utf8")).is_file()
-            and (item_mtime_alt < Path(str(album.artpath, "utf8")).stat().st_mtime)
-        ):
+        if self._should_embed_art(item, actual):
             actions.append(Action.SYNC_ART)
 
         return actions
@@ -450,6 +503,9 @@ class External:
                             shutil.copyfile(item.path, dest)
                             if self._config.album_art_embed:
                                 self._sync_art(item, dest)
+                            else:
+                                # Strip embedded art if not embedding
+                                self._clear_embedded_art(dest)
                             self._set_stored_path(item, dest)
                             item.store()
 
@@ -490,11 +546,19 @@ class External:
             if not dest_dir:
                 continue
 
-            artpath = album.artpath and Path(str(album.artpath, "utf8"))
-            if not artpath or not artpath.is_file():
+            # Determine which art source to use based on preference
+            artpath = self._get_art_for_album(album, link)
+            if not artpath:
                 continue
 
-            dest = album.art_destination(album.artpath, bytes(dest_dir))
+            # Determine destination path and filename
+            if album.artpath:
+                dest = album.art_destination(album.artpath, bytes(dest_dir))
+            else:
+                # Fallback filename when no external artpath - use configured art_filename
+                art_filename = beets.config["art_filename"].get(str) or "cover"
+                dest = bytes(dest_dir) + b"/" + art_filename.encode("utf8") + b".jpg"
+
             dest = Path(str(dest, "utf8"))
 
             if self._config.album_art_format and not link:
@@ -518,6 +582,39 @@ class External:
                 util.copy(path, bytes(dest), replace=True)
 
             print_(f"~{dest}")
+
+    def _get_art_for_album(self, album: Album, link: bool = False) -> Path | None:
+        """Get art for an album based on album_art_source preference.
+
+        Returns the path to the art file to use, or None if no art should be copied.
+        For embedded art, extracts to a temp file and returns that path.
+        """
+        source_pref = self._config.album_art_source
+
+        # Check what art sources are available
+        external_art = None
+        if album.artpath:
+            external_art = Path(str(album.artpath, "utf8"))
+            if not external_art.is_file():
+                external_art = None
+
+        embedded_art: Path | None = None
+        if not link:  # Don't try to extract embedded for symlinks
+            items = album.items()
+            if items:
+                embedded_art_bytes = self._extract_embedded_art(items[0])
+                if embedded_art_bytes:
+                    embedded_art = Path(str(embedded_art_bytes, "utf8"))
+
+        # Choose which art to use based on preference
+        if source_pref == AlbumArtSource.EMBEDDED:
+            return embedded_art or external_art
+        elif source_pref == AlbumArtSource.EXTERNAL:
+            return external_art or embedded_art
+        elif source_pref == AlbumArtSource.EMBEDDED_ONLY:
+            return embedded_art
+        else:  # EXTERNAL_ONLY
+            return external_art
 
     def resize_art(self, path: bytes) -> bytes:
         """Resize the candidate artwork according to the plugin's
@@ -599,11 +696,29 @@ class External:
     def _sync_art(self, item: Item, path: Path):
         """Embed artwork in the file at `path`."""
         album = item.get_album()
-        if album and album.artpath and Path(str(album.artpath, "utf8")).is_file():
-            self._log.debug(f"Embedding art from {album.artpath} into {path}")
+        artpath: bytes | None = None
+        source_pref = self._config.album_art_source
 
-            artpath = self.resize_art(album.artpath)
+        if source_pref in (AlbumArtSource.EMBEDDED, AlbumArtSource.EMBEDDED_ONLY):
+            # Prefer or only use embedded art from source file
+            artpath = self._extract_embedded_art(item)
+            if (
+                not artpath
+                and source_pref == AlbumArtSource.EMBEDDED
+                and album
+                and album.artpath
+            ):
+                self._log.debug(f"Embedding art from {album.artpath} into {path}")
+                artpath = self.resize_art(album.artpath)
+        else:
+            # Prefer or only use external artpath
+            if album and album.artpath and Path(str(album.artpath, "utf8")).is_file():
+                self._log.debug(f"Embedding art from {album.artpath} into {path}")
+                artpath = self.resize_art(album.artpath)
+            if not artpath and source_pref == AlbumArtSource.EXTERNAL:
+                artpath = self._extract_embedded_art(item)
 
+        if artpath:
             art.embed_item(
                 self._log,
                 item,
@@ -611,6 +726,47 @@ class External:
                 maxwidth=self._config.album_art_maxwidth,
                 itempath=bytes(path),
             )
+        elif source_pref == AlbumArtSource.EXTERNAL_ONLY:
+            # external-only mode with no external art: clear any embedded art
+            self._clear_embedded_art(Path(path))
+
+    def _has_embedded_art(self, item: Item) -> bool:
+        """Check if the source item has embedded artwork."""
+        try:
+            mf = MediaFile(str(item.path, "utf8"))
+            return mf.art is not None
+        except (OSError, KeyError):
+            return False
+
+    def _clear_embedded_art(self, path: Path) -> None:
+        """Remove embedded artwork from a media file."""
+        try:
+            mf = MediaFile(str(path))
+            if mf.art is not None:
+                mf.art = None
+                mf.save()
+                self._log.debug(f"Cleared embedded art from {path}")
+        except (OSError, KeyError):
+            pass
+
+    def _extract_embedded_art(self, item: Item) -> bytes | None:
+        """Extract embedded artwork from the source item and optionally resize it.
+
+        Returns the path to the resized art as bytes, or None if no art was found.
+        """
+        # Read embedded art from the source item file
+        mf = MediaFile(str(item.path, "utf8"))
+        if not mf.art:
+            return None
+
+        # Save the embedded art to a temporary file
+        temp_path = util.get_temp_filename(__name__, "embedded_art", suffix=".jpg")
+        Path(str(temp_path, "utf8")).write_bytes(mf.art)
+
+        self._log.debug(f"Extracted embedded art from {item.path} to {temp_path}")
+
+        # Resize the art if needed
+        return self.resize_art(temp_path)
 
     def _should_transcode(self, item: Item) -> bool:
         return False

--- a/beetsplug/alternatives.py
+++ b/beetsplug/alternatives.py
@@ -288,9 +288,9 @@ class Config:
         assert isinstance(album_art_source_str, str)
         self.album_art_source = AlbumArtSource(album_art_source_str)
 
-        album_art_different_embedded_prompt = config["album_art_different_embedded_prompt"].get(
-            confuse.TypeTemplate(bool, default=True)
-        )
+        album_art_different_embedded_prompt = config[
+            "album_art_different_embedded_prompt"
+        ].get(confuse.TypeTemplate(bool, default=True))
         assert isinstance(album_art_different_embedded_prompt, bool)
         self.album_art_different_embedded_prompt = album_art_different_embedded_prompt
 
@@ -622,7 +622,12 @@ class External:
                 external_art = None
 
         embedded_art: Path | None = None
-        if not link:  # Don't try to extract embedded for symlinks
+        # Don't try to extract embedded for symlinks or if we're gonna ignore
+        # the result.
+        skip_embedded = source_pref == AlbumArtSource.EXTERNAL_ONLY or (
+            source_pref == AlbumArtSource.EXTERNAL and external_art is not None
+        )
+        if not (link or skip_embedded):
             items = album.items()
             if items:
                 # Check if all items have the same embedded art. If items have
@@ -653,7 +658,9 @@ class External:
                         )
 
                 if use_embedded and first_valid_index is not None:
-                    embedded_art_bytes = self._extract_embedded_art(items[first_valid_index])
+                    embedded_art_bytes = self._extract_embedded_art(
+                        items[first_valid_index]
+                    )
                     if embedded_art_bytes:
                         embedded_art = Path(str(embedded_art_bytes, "utf8"))
 

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -579,25 +579,44 @@ class TestExternalArt(TestHelper):
         ("album_art_source", "album_art_embed", "album_art_copy", "embed", "external"),
         [
             # Test all preferences with both embed and copy enabled across source combinations
-            *list(product(AlbumArtSource, [True], [True], [True], [False])),  # embed only
-            *list(product(AlbumArtSource, [True], [True], [False], [True])),  # external only
-            *list(product(AlbumArtSource, [True], [True], [True], [True])),  # both sources
+            *list(
+                product(AlbumArtSource, [True], [True], [True], [False])
+            ),  # embed only
+            *list(
+                product(AlbumArtSource, [True], [True], [False], [True])
+            ),  # external only
+            *list(
+                product(AlbumArtSource, [True], [True], [True], [True])
+            ),  # both sources
             # Test other cases
             (AlbumArtSource.EMBEDDED, True, False, True, False),  # embed only, no copy
             (AlbumArtSource.EMBEDDED, False, True, False, True),  # copy only, no embed
-            (AlbumArtSource.EMBEDDED, False, False, False, False),  # neither embed nor copy
-        ]
+            (
+                AlbumArtSource.EMBEDDED,
+                False,
+                False,
+                False,
+                False,
+            ),  # neither embed nor copy
+        ],
     )
-    def test_album_art_source(self, album_art_source: AlbumArtSource,
-                              album_art_embed: bool, album_art_copy: bool,
-                              embed: bool, external: bool):
+    def test_album_art_source(
+        self,
+        album_art_source: AlbumArtSource,
+        album_art_embed: bool,
+        album_art_copy: bool,
+        embed: bool,
+        external: bool,
+    ):
         self.external_config["album_art_source"] = album_art_source.value
         self.external_config["album_art_copy"] = album_art_copy
         self.external_config["album_art_embed"] = album_art_embed
 
         embedded_art = self.IMAGE_FIXTURE1 if embed else None
         external_art = self.IMAGE_FIXTURE2 if external else None
-        album = self.add_album(embed_art=embedded_art, external_art=external_art, myexternal="true")
+        album = self.add_album(
+            embed_art=embedded_art, external_art=external_art, myexternal="true"
+        )
         item = album.items().get()
         assert item
 
@@ -615,34 +634,62 @@ class TestExternalArt(TestHelper):
         self.runcli("alt", "update", "myexternal")
         item.load()
 
-        assert_has_artwork(self.get_path(item), album_art_embed, album_art_copy, expected_art)
+        compare_embedded = expected_art if album_art_embed else None
+        compare_external = expected_art if album_art_copy else None
+        assert_has_artwork(self.get_path(item), compare_embedded, compare_external)
 
     @pytest.mark.parametrize(
-        ("embed_art_indicies", "user_resp", "result_index"),
+        (
+            "prompt",
+            "album_art_source",
+            "embed_art_indicies",
+            "user_resp",
+            "result_index",
+        ),
         [
-            ([0, 0, 0], None, 0),
-            ([1, 1, 1], None, 1),
-            ([0, 1, 2], "y", 1),
-            ([0, 1, 2], "n", None),
-        ]
+            # Embedded only, but no embedded art, no prompt
+            (True, AlbumArtSource.EMBEDDED_ONLY, [0, 0, 0], None, 0),
+            # External preferred, no prompt
+            (True, AlbumArtSource.EXTERNAL, [0, 1, 2], None, 2),
+            # External only, no prompt
+            (True, AlbumArtSource.EXTERNAL_ONLY, [0, 1, 2], None, 2),
+            # Embedded preferred, all embedded the same, no prompt
+            (True, AlbumArtSource.EMBEDDED, [1, 1, 1], None, 1),
+            # Embedded preferred, different embedded, prompt yes, first image
+            (True, AlbumArtSource.EMBEDDED, [0, 1, 2], "y", 1),
+            # Embedded preferred, different embedded, prompt no, exit
+            (True, AlbumArtSource.EMBEDDED, [0, 1, 2], "n", None),
+            # Don't prompt, Embedded preferred, different embedded, no prompt, first image
+            (False, AlbumArtSource.EMBEDDED, [0, 1, 2], None, 1),
+        ],
     )
-    def test_different_embedded_art(self, embed_art_indicies, user_resp, result_index):
-        self.external_config["album_art_source"] = AlbumArtSource.EMBEDDED.value
+    def test_different_embedded_art(
+        self,
+        prompt: bool,
+        album_art_source: AlbumArtSource,
+        embed_art_indicies: list[int],
+        user_resp: str | None,
+        result_index: int,
+    ):
+        self.external_config["album_art_different_embedded_prompt"] = prompt
+        self.external_config["album_art_source"] = album_art_source.value
         self.external_config["album_art_copy"] = True
         self.external_config["album_art_embed"] = False
 
-        imgs = [None, self.IMAGE_FIXTURE1, self.IMAGE_FIXTURE1]
+        imgs = [None, self.IMAGE_FIXTURE1, self.IMAGE_FIXTURE2]
         album = self.add_album(
             track_count=len(embed_art_indicies),
             embed_art=[imgs[i] for i in embed_art_indicies],
+            external_art=self.IMAGE_FIXTURE2,
             myexternal="true",
         )
 
         if user_resp is None:
             out = self.runcli("alt", "update", "myexternal")
         elif user_resp == "n":
-            with control_stdin(user_resp), pytest.raises(
-                UserError, match="Update cancelled by user"
+            with (
+                control_stdin(user_resp),
+                pytest.raises(UserError, match="Update cancelled by user"),
             ):
                 self.runcli("alt", "update", "myexternal")
             return
@@ -654,7 +701,7 @@ class TestExternalArt(TestHelper):
         result_img = imgs[result_index]
         for item in album.items():
             item.load()
-            assert_has_artwork(self.get_path(item), False, True, result_img)
+            assert_has_artwork(self.get_path(item), None, result_img)
 
 
 class TestExternalConvert(TestHelper):

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -21,6 +21,7 @@ from beetsplug.alternatives import AlbumArtSource
 from .helper import (
     TestHelper,
     assert_file_tag,
+    assert_has_artwork,
     assert_has_embedded_artwork,
     assert_has_not_embedded_artwork,
     assert_is_not_file,
@@ -594,51 +595,66 @@ class TestExternalArt(TestHelper):
         self.external_config["album_art_copy"] = album_art_copy
         self.external_config["album_art_embed"] = album_art_embed
 
-        album = self.add_album(myexternal="true")
+        embedded_art = self.IMAGE_FIXTURE1 if embed else None
+        external_art = self.IMAGE_FIXTURE2 if external else None
+        album = self.add_album(embed_art=embedded_art, external_art=external_art, myexternal="true")
         item = album.items().get()
         assert item
 
-        embedded_image = self.IMAGE_FIXTURE1
-        if embed:
-            source_mf = MediaFile(str(item.path, "utf8"))
-            with self.IMAGE_FIXTURE1.open("rb") as f:
-                source_mf.art = f.read()
-            source_mf.save()
-
-        external_image = self.IMAGE_FIXTURE2
-        if external:
-            album.set_art(self.IMAGE_FIXTURE2)
-            album.store()
-
-        expected_image = None
+        expected_art = None
         if embed or external:
             if album_art_source == AlbumArtSource.EMBEDDED:
-                expected_image = embedded_image if embed else external_image
+                expected_art = embedded_art if embed else external_art
             elif album_art_source == AlbumArtSource.EXTERNAL:
-                expected_image = external_image if external else embedded_image
+                expected_art = external_art if external else embedded_art
             elif album_art_source == AlbumArtSource.EMBEDDED_ONLY and embed:
-                expected_image = embedded_image
+                expected_art = embedded_art
             elif album_art_source == AlbumArtSource.EXTERNAL_ONLY and external:
-                expected_image = external_image
+                expected_art = external_art
 
         self.runcli("alt", "update", "myexternal")
         item.load()
 
-        external_path = self.get_path(item)
+        assert_has_artwork(self.get_path(item), album_art_embed, album_art_copy, expected_art)
 
-        # Assert embedded art
-        if album_art_embed and expected_image:
-            assert_has_embedded_artwork(external_path, expected_image)
-        else:
-            assert_has_not_embedded_artwork(external_path)
+    @pytest.mark.parametrize(
+        ("embed_art_indicies", "user_resp", "result_index"),
+        [
+            ([0, 0, 0], None, 0),
+            ([1, 1, 1], None, 1),
+            ([0, 1, 2], "y", 1),
+            ([0, 1, 2], "n", None),
+        ]
+    )
+    def test_different_embedded_art(self, embed_art_indicies, user_resp, result_index):
+        self.external_config["album_art_source"] = AlbumArtSource.EMBEDDED.value
+        self.external_config["album_art_copy"] = True
+        self.external_config["album_art_embed"] = False
 
-        # Assert external art file
-        art_files = list(external_path.parent.glob("COVER*"))
-        if album_art_copy and expected_image:
-            assert art_files, "Expected art file but none found"
-            assert_same_file_content(art_files[0], expected_image)
+        imgs = [None, self.IMAGE_FIXTURE1, self.IMAGE_FIXTURE1]
+        album = self.add_album(
+            track_count=len(embed_art_indicies),
+            embed_art=[imgs[i] for i in embed_art_indicies],
+            myexternal="true",
+        )
+
+        if user_resp is None:
+            out = self.runcli("alt", "update", "myexternal")
+        elif user_resp == "n":
+            with control_stdin(user_resp), pytest.raises(
+                UserError, match="Update cancelled by user"
+            ):
+                self.runcli("alt", "update", "myexternal")
+            return
         else:
-            assert not art_files, f"Unexpected art files: {art_files}"
+            with control_stdin(user_resp):
+                out = self.runcli("alt", "update", "myexternal")
+                assert "Use first art found?" in out
+
+        result_img = imgs[result_index]
+        for item in album.items():
+            item.load()
+            assert_has_artwork(self.get_path(item), False, True, result_img)
 
 
 class TestExternalConvert(TestHelper):

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -1,5 +1,6 @@
 import io
 import platform
+from itertools import product
 from pathlib import Path
 from time import sleep
 
@@ -14,6 +15,8 @@ from beets.util.functemplate import Template
 from confuse import ConfigValueError
 from mediafile import MediaFile
 from PIL import Image
+
+from beetsplug.alternatives import AlbumArtSource
 
 from .helper import (
     TestHelper,
@@ -570,6 +573,72 @@ class TestExternalArt(TestHelper):
         width, height = Image.open(io.BytesIO(mediafile.art)).size  # pyright: ignore
         assert width == 1
         assert height < 3
+
+    @pytest.mark.parametrize(
+        ("album_art_source", "album_art_embed", "album_art_copy", "embed", "external"),
+        [
+            # Test all preferences with both embed and copy enabled across source combinations
+            *list(product(AlbumArtSource, [True], [True], [True], [False])),  # embed only
+            *list(product(AlbumArtSource, [True], [True], [False], [True])),  # external only
+            *list(product(AlbumArtSource, [True], [True], [True], [True])),  # both sources
+            # Test other cases
+            (AlbumArtSource.EMBEDDED, True, False, True, False),  # embed only, no copy
+            (AlbumArtSource.EMBEDDED, False, True, False, True),  # copy only, no embed
+            (AlbumArtSource.EMBEDDED, False, False, False, False),  # neither embed nor copy
+        ]
+    )
+    def test_album_art_source(self, album_art_source: AlbumArtSource,
+                              album_art_embed: bool, album_art_copy: bool,
+                              embed: bool, external: bool):
+        self.external_config["album_art_source"] = album_art_source.value
+        self.external_config["album_art_copy"] = album_art_copy
+        self.external_config["album_art_embed"] = album_art_embed
+
+        album = self.add_album(myexternal="true")
+        item = album.items().get()
+        assert item
+
+        embedded_image = self.IMAGE_FIXTURE1
+        if embed:
+            source_mf = MediaFile(str(item.path, "utf8"))
+            with self.IMAGE_FIXTURE1.open("rb") as f:
+                source_mf.art = f.read()
+            source_mf.save()
+
+        external_image = self.IMAGE_FIXTURE2
+        if external:
+            album.set_art(self.IMAGE_FIXTURE2)
+            album.store()
+
+        expected_image = None
+        if embed or external:
+            if album_art_source == AlbumArtSource.EMBEDDED:
+                expected_image = embedded_image if embed else external_image
+            elif album_art_source == AlbumArtSource.EXTERNAL:
+                expected_image = external_image if external else embedded_image
+            elif album_art_source == AlbumArtSource.EMBEDDED_ONLY and embed:
+                expected_image = embedded_image
+            elif album_art_source == AlbumArtSource.EXTERNAL_ONLY and external:
+                expected_image = external_image
+
+        self.runcli("alt", "update", "myexternal")
+        item.load()
+
+        external_path = self.get_path(item)
+
+        # Assert embedded art
+        if album_art_embed and expected_image:
+            assert_has_embedded_artwork(external_path, expected_image)
+        else:
+            assert_has_not_embedded_artwork(external_path)
+
+        # Assert external art file
+        art_files = list(external_path.parent.glob("COVER*"))
+        if album_art_copy and expected_image:
+            assert art_files, "Expected art file but none found"
+            assert_same_file_content(art_files[0], expected_image)
+        else:
+            assert not art_files, f"Unexpected art files: {art_files}"
 
 
 class TestExternalConvert(TestHelper):

--- a/test/helper.py
+++ b/test/helper.py
@@ -124,17 +124,18 @@ def assert_has_not_embedded_artwork(path: Path):
     assert mediafile.art is None, "MediaFile has embedded artwork"
 
 
-def assert_has_artwork(path: Path, compare_embedded: bool, compare_external: bool,
-                       compare_file: Path | None):
-    if compare_embedded and compare_file:
-        assert_has_embedded_artwork(path, compare_file)
+def assert_has_artwork(
+    path: Path, compare_embedded: Path | None, compare_external: Path | None
+):
+    if compare_embedded:
+        assert_has_embedded_artwork(path, compare_embedded)
     else:
         assert_has_not_embedded_artwork(path)
 
     art_files = list(path.parent.glob("COVER*"))
-    if compare_external and compare_file:
+    if compare_external:
         assert art_files, "Expected art file but none found"
-        assert_same_file_content(art_files[0], compare_file)
+        assert_same_file_content(art_files[0], compare_external)
     else:
         assert not art_files, f"Unexpected art files: {art_files}"
 
@@ -193,7 +194,9 @@ class TestHelper:
         for fixture_file in self.fixture_dir.rglob("*"):
             if fixture_file.is_file():
                 relative_path = fixture_file.relative_to(self.fixture_dir)
-                self._fixture_checksums[str(relative_path)] = crc32(fixture_file.read_bytes())
+                self._fixture_checksums[str(relative_path)] = crc32(
+                    fixture_file.read_bytes()
+                )
 
         self._lib_tracker = _LibraryTracker()
 
@@ -211,7 +214,10 @@ class TestHelper:
             if fixture_file.is_file():
                 relative_path = fixture_file.relative_to(self.fixture_dir)
                 path_str = str(relative_path)
-                if crc32(fixture_file.read_bytes()) != self._fixture_checksums[path_str]:
+                if (
+                    crc32(fixture_file.read_bytes())
+                    != self._fixture_checksums[path_str]
+                ):
                     fixtures_modified.append(path_str)
 
         if fixtures_modified:
@@ -267,7 +273,13 @@ class TestHelper:
         assert fmt in {"mp3", "m4a", "ogg"}
         return self.fixture_dir / f"min.{fmt}"
 
-    def add_album(self, track_count=1, embed_art=None, external_art=None, **kwargs):
+    def add_album(
+        self,
+        track_count: int = 1,
+        embed_art: Path | list[Path | None] | None = None,
+        external_art: Path | None = None,
+        **kwargs: str,
+    ):
         assert track_count >= 1
         if embed_art is None:
             embed_art = []
@@ -287,11 +299,14 @@ class TestHelper:
         album.store()
         return album
 
-    def add_track(self, **kwargs: str):
-        embed_art = kwargs.pop("embed_art", None)
-        title_no = kwargs.pop("title_no", 1)
-        artist_no = kwargs.pop("artist_no", 1)
-        album_no = kwargs.pop("album_no", 1)
+    def add_track(
+        self,
+        embed_art: Path | None = None,
+        title_no: int = 1,
+        artist_no: int = 1,
+        album_no: int = 1,
+        **kwargs: str,
+    ):
         values = {
             "title": f"track {title_no}",
             "artist": f"artist {artist_no}",

--- a/test/helper.py
+++ b/test/helper.py
@@ -6,6 +6,7 @@ import sys
 from collections import defaultdict
 from contextlib import contextmanager
 from io import StringIO
+from itertools import zip_longest
 from pathlib import Path
 from zlib import crc32
 
@@ -123,6 +124,21 @@ def assert_has_not_embedded_artwork(path: Path):
     assert mediafile.art is None, "MediaFile has embedded artwork"
 
 
+def assert_has_artwork(path: Path, compare_embedded: bool, compare_external: bool,
+                       compare_file: Path | None):
+    if compare_embedded and compare_file:
+        assert_has_embedded_artwork(path, compare_file)
+    else:
+        assert_has_not_embedded_artwork(path)
+
+    art_files = list(path.parent.glob("COVER*"))
+    if compare_external and compare_file:
+        assert art_files, "Expected art file but none found"
+        assert_same_file_content(art_files[0], compare_file)
+    else:
+        assert not art_files, f"Unexpected art files: {art_files}"
+
+
 def assert_media_file_fields(path: Path, **kwargs: str):
     mediafile = MediaFile(path)
     for k, v in kwargs.items():
@@ -172,6 +188,13 @@ class TestHelper:
         self.IMAGE_FIXTURE1 = self.fixture_dir / "image.png"
         self.IMAGE_FIXTURE2 = self.fixture_dir / "image_black.png"
 
+        # Record checksums for all fixture files to ensure tests don't modify them
+        self._fixture_checksums = {}
+        for fixture_file in self.fixture_dir.rglob("*"):
+            if fixture_file.is_file():
+                relative_path = fixture_file.relative_to(self.fixture_dir)
+                self._fixture_checksums[str(relative_path)] = crc32(fixture_file.read_bytes())
+
         self._lib_tracker = _LibraryTracker()
 
         beets.plugins._instances = [
@@ -181,6 +204,20 @@ class TestHelper:
         ]
 
         yield
+
+        # Verify fixture files weren't modified during the test
+        fixtures_modified = []
+        for fixture_file in self.fixture_dir.rglob("*"):
+            if fixture_file.is_file():
+                relative_path = fixture_file.relative_to(self.fixture_dir)
+                path_str = str(relative_path)
+                if crc32(fixture_file.read_bytes()) != self._fixture_checksums[path_str]:
+                    fixtures_modified.append(path_str)
+
+        if fixtures_modified:
+            raise AssertionError(
+                f"Test modified fixture file(s): {', '.join(fixtures_modified)}"
+            )
 
         self._lib_tracker.close_all()
 
@@ -230,29 +267,35 @@ class TestHelper:
         assert fmt in {"mp3", "m4a", "ogg"}
         return self.fixture_dir / f"min.{fmt}"
 
-    def add_album(self, **kwargs: str):
-        values = {
-            "title": "track 1",
-            "artist": "artist 1",
-            "album": "album 1",
-            "format": "mp3",
-        }
-        values.update(kwargs)
-        item = Item.from_path(str(self.item_fixture_path(values.pop("format"))))
-        item.add(self.lib)
-        item.update(values)
-        item.move(MoveOperation.COPY)
-        item.write()
-        album = self.lib.add_album([item])
-        album.albumartist = item.artist
+    def add_album(self, track_count=1, embed_art=None, external_art=None, **kwargs):
+        assert track_count >= 1
+        if embed_art is None:
+            embed_art = []
+        elif not isinstance(embed_art, list):
+            embed_art = [embed_art]
+        tracks = []
+        for i, art in zip_longest(range(track_count), embed_art):
+            if i is None:
+                break
+            track = self.add_track(title_no=i + 1, embed_art=art, **kwargs)
+            tracks.append(track)
+
+        album = self.lib.add_album(tracks)
+        album.albumartist = tracks[0].artist
+        if external_art is not None:
+            album.set_art(external_art)
         album.store()
         return album
 
     def add_track(self, **kwargs: str):
+        embed_art = kwargs.pop("embed_art", None)
+        title_no = kwargs.pop("title_no", 1)
+        artist_no = kwargs.pop("artist_no", 1)
+        album_no = kwargs.pop("album_no", 1)
         values = {
-            "title": "track 1",
-            "artist": "artist 1",
-            "album": "album 1",
+            "title": f"track {title_no}",
+            "artist": f"artist {artist_no}",
+            "album": f"album {album_no}",
             "format": "mp3",
         }
         values.update(kwargs)
@@ -262,6 +305,13 @@ class TestHelper:
         item.update(values)
         item.move(MoveOperation.COPY)
         item.write()
+
+        if embed_art is not None:
+            mf = MediaFile(str(item.path, "utf8"))
+            with embed_art.open("rb") as f:
+                mf.art = f.read()
+            mf.save()
+
         return item
 
     def add_external_track(self, ext_name: str, **kwargs: str):


### PR DESCRIPTION
Fixes https://github.com/geigerzaehler/beets-alternatives/issues/69 by adding support for reading embedded cover art in the main collection. This allows resizing and deinterlacing embedded art for the external collection. The preference between using external art files and embedded art is configurable using `album_art_source`.

Also the behavior of `album_art_embed=false` was changed to strip existing embedded art from the files in the external collection for consistency.